### PR TITLE
Use service name derived from config when using `immortal -c service.yml`

### DIFF
--- a/cmd/immortalctl/main.go
+++ b/cmd/immortalctl/main.go
@@ -185,6 +185,9 @@ func main() {
 			} else {
 				s.Status = status
 				s.SignalResponse = res
+				if len(s.Status.Name) > 0 { // Override name if provided
+					s.Name = s.Status.Name
+				}
 				queue <- &Pad{
 					pid:  len(fmt.Sprintf("%d", status.Pid)),
 					up:   len(status.Up),

--- a/cmd/immortalctl/main.go
+++ b/cmd/immortalctl/main.go
@@ -4,8 +4,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"os/user"
-	"path/filepath"
 	"sync"
 	"time"
 
@@ -145,18 +143,8 @@ func main() {
 	// get status for all services
 	services, _ := ctl.FindServices(sdir)
 
-	// get user $HOME/.immortal services
-	home := os.Getenv("HOME")
-	if home == "" {
-		usr, err := user.Current()
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "error getting user home: %s\n", err)
-			os.Exit(1)
-		}
-		home = usr.HomeDir
-	}
 	if userServices, err := ctl.FindServices(
-		filepath.Join(home, ".immortal"),
+		immortal.GetUserdir(),
 	); err == nil {
 		services = append(services, userServices...)
 	}

--- a/config.go
+++ b/config.go
@@ -8,6 +8,7 @@ import (
 type Config struct {
 	Cmd     string            `yaml:"cmd" json:"cmd"`
 	Cwd     string            `yaml:",omitempty" json:",omitempty"`
+	Name    string            `yaml:"name,omitempty" json:"name,omitempty"`
 	Env     map[string]string `yaml:",omitempty" json:",omitempty"`
 	Log     Log               `yaml:",omitempty" json:",omitempty"`
 	Stderr  Log               `yaml:",omitempty" json:",omitempty"`

--- a/funcs.go
+++ b/funcs.go
@@ -9,6 +9,8 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"os/user"
+	"path/filepath"
 	"time"
 )
 
@@ -83,6 +85,20 @@ func inSlice(s []string, item string) bool {
 		}
 	}
 	return false
+}
+
+// GetUserdir returns the $HOME/.immortal
+func GetUserdir() string {
+	home := os.Getenv("HOME")
+	if home == "" {
+		usr, err := user.Current()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error getting user home: %s\n", err)
+			os.Exit(1)
+		}
+		home = usr.HomeDir
+	}
+	return filepath.Join(home, ".immortal")
 }
 
 // GetSdir return the main supervise directory, defaults to /var/run/immortal

--- a/funcs.go
+++ b/funcs.go
@@ -92,11 +92,9 @@ func GetUserdir() string {
 	home := os.Getenv("HOME")
 	if home == "" {
 		usr, err := user.Current()
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "error getting user home: %s\n", err)
-			os.Exit(1)
+		if err == nil {
+			home = usr.HomeDir
 		}
-		home = usr.HomeDir
 	}
 	return filepath.Join(home, ".immortal")
 }

--- a/funcs_test.go
+++ b/funcs_test.go
@@ -64,8 +64,13 @@ func TestInSlice(t *testing.T) {
 
 func TestGetUserdir(t *testing.T) {
 	oldHome := os.Getenv("HOME")
+
 	os.Setenv("HOME", "/tmp/foo")
 	expect(t, GetUserdir(), filepath.Join("/tmp/foo", ".immortal"))
+
+	os.Setenv("HOME", "")
+	expect(t, GetUserdir(), filepath.Join(oldHome, ".immortal"))
+
 	os.Setenv("HOME", oldHome)
 }
 

--- a/funcs_test.go
+++ b/funcs_test.go
@@ -3,6 +3,7 @@ package immortal
 import (
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -59,6 +60,13 @@ func TestInSlice(t *testing.T) {
 			t.Error(tt.slice)
 		}
 	}
+}
+
+func TestGetUserdir(t *testing.T) {
+	oldHome := os.Getenv("HOME")
+	os.Setenv("HOME", "/tmp/foo")
+	expect(t, GetUserdir(), filepath.Join("/tmp/foo", ".immortal"))
+	os.Setenv("HOME", oldHome)
 }
 
 func TestIsDir(t *testing.T) {

--- a/parser.go
+++ b/parser.go
@@ -188,6 +188,8 @@ func ParseArgs(p Parser, fs *flag.FlagSet) (cfg *Config, err error) {
 				return
 			}
 		}
+		serviceFile := filepath.Base(flags.Configfile)
+		cfg.Name = strings.TrimSuffix(serviceFile, filepath.Ext(serviceFile))
 		cfg.ctl = sdir
 		return
 	}

--- a/socket.go
+++ b/socket.go
@@ -23,6 +23,7 @@ type Status struct {
 	Fpid   bool   `json:"fpid"`
 	Count  uint32 `json:"count"`
 	Status string `json:"status,omitempty"`
+	Name   string `json:"name,omitempty"`
 }
 
 // Listen creates a unix socket used for control the daemon
@@ -58,6 +59,9 @@ func (d *Daemon) HandleStatus(w http.ResponseWriter, r *http.Request) {
 	} else {
 		startin := d.process.sTime.Add(time.Duration(d.cfg.Wait) * time.Second)
 		status.Status = fmt.Sprintf("Starting in %0.1f seconds", startin.Sub(time.Now()).Seconds())
+	}
+	if len(d.cfg.Name) > 0 {
+		status.Name = d.cfg.Name
 	}
 
 	// return status in json


### PR DESCRIPTION
This PR  makes the processes started directly with immortal addressible by the service name as derived from the config filename. This mirrors the behaviour of `immortaldir`. I have a use case where I need to use the `require` directive for monitored processes which are not started by immortaldir but directly by immortal itself. Currently such process have the PID as name. This makes using require impossible. Feedback appreciated. 

To further elaborate on the use case. We are using this modified version of immortal in combination with https://github.com/Supervisor/supervisor which has pretty clumsy dependency support. Immortal solves this in a very simple in effective manner. Reason for using supervisor is that we can, at this time, better control the stdout/stderr redirection for monitored processes inside container environments. Ideally we would just use immortal so investigating this further.
