### PR TITLE
Nodaemon flag

### DIFF
--- a/cmd/immortal/main.go
+++ b/cmd/immortal/main.go
@@ -36,6 +36,12 @@ func main() {
 		os.Exit(0)
 	}
 
+	// nodaemon check
+	nodaemon := false
+	if (fs.Lookup("n")).Value.(flag.Getter).Get().(bool) {
+		nodaemon = true
+	}
+
 	// log to syslog
 	logger, err := syslog.New(syslog.LOG_NOTICE|syslog.LOG_DAEMON, "immortal")
 	if err == nil {
@@ -76,7 +82,7 @@ func main() {
 	}
 
 	// fork
-	if os.Getppid() > 1 {
+	if !nodaemon && os.Getppid() > 1 {
 		if pid, err := immortal.Fork(); err != nil {
 			log.Fatalf("error while forking: %s", err)
 		} else {

--- a/flags.go
+++ b/flags.go
@@ -14,6 +14,7 @@ type Flags struct {
 	Retries    uint
 	User       string
 	Version    bool
+	Nodaemon   bool
 	Wait       uint
 	Wrkdir     string
 }

--- a/parser.go
+++ b/parser.go
@@ -33,6 +33,7 @@ type Parse struct {
 // Parse parse the command line flags
 func (p *Parse) Parse(fs *flag.FlagSet) (*Flags, error) {
 	fs.BoolVar(&p.Flags.Version, "v", false, "Print version")
+	fs.BoolVar(&p.Flags.Nodaemon, "n", false, "No daemon")
 	fs.UintVar(&p.Flags.Retries, "r", 0, "`number` of retries before program exit")
 	fs.UintVar(&p.Flags.Wait, "w", 0, "`seconds` to wait before starting")
 	fs.StringVar(&p.Flags.ChildPid, "p", "", "Path to write the child `pidfile`")


### PR DESCRIPTION
This adds a -n flag to immortal which does not make it fork to the background. This is useful for testing and also in cases immortal is executed from another processes which wants it to stay in the foreground.