### PR TITLE
Not to close pipe even when Scan() fails

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -31,7 +31,7 @@ func (l *LogWriter) Log(input io.ReadCloser) {
 		for in.Scan() {
 			l.logger.Print(in.Text())
 		}
-		if in.Err() == io.EOF {
+		if in.Err() == io.EOF || in.Err() == nil {
 			break
 		}
 		// If non EOF error happens, we dump the log and not to close the pipe.

--- a/logger.go
+++ b/logger.go
@@ -26,9 +26,17 @@ type LogWriter struct {
 
 // Log write to the logger
 func (l *LogWriter) Log(input io.ReadCloser) {
-	in := bufio.NewScanner(input)
-	for in.Scan() {
-		l.logger.Print(in.Text())
+	for {
+		in := bufio.NewScanner(input)
+		for in.Scan() {
+			l.logger.Print(in.Text())
+		}
+		if in.Err() == io.EOF {
+			break
+		}
+		// If non EOF error happens, we dump the log and not to close the pipe.
+		// Calling input.Close() right away may trigger SIGPIPE signal to the daemon and restart.
+		l.logger.Printf("immortal failed to scan log input: %v", in.Err())
 	}
 	input.Close()
 }


### PR DESCRIPTION
- [x] Have you test the code?
- [x] Have you check that the existing tests are passing?
- [x] The destination branch is **develop**?

Let's say when you run the following child program:
```
func main() {
	i := 0
	for {
		fmt.Println(i)
		i++
		time.Sleep(time.Second)
		if i%3 == 0 {
			buf := make([]byte, 1000*1000)
			fmt.Println("%v", buf)
		}
	}
}
```

Every three seconds, it dumps big `[]byte` array. This is not well written program though, but it may happen if you dump the whole struct.

When immortal captures the whole text coming from the child process, `Scan()` fails and `Err()` truns `bufio.ErrTooLong`. And the current code doesn't check the error and it close the pipe.

The closing pipe triggers `SIGPIPE` signal to the child and the child process is killed. In this case, the process is killed always after three seconds since it starts.

This patch mitigates not to trigger `SIGPIPE` signal even if the child process dumps long text log.
 



