### PR TITLE
Addresses #74, ability to match services by commands.

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,15 @@ structure:
        |--lock
        `--immortal.sock
 
+The `-name` argument takes a non-path (e.g., "myservice"), and the argument will be used instead of the pid in the directory structure. For example, `immortal -ctl myservice sleep 1000` will be:
+
+    ~/.immortal
+    |--myservice
+    |  |--lock
+    |  `--immortal.sock
+
+The `-ctl` argument takes precedence over the `-name` argument.
+
 # immortalctl
 
 Will print current status and allow to manage the services

--- a/config.go
+++ b/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	command    []string
 	configFile string
 	ctl        string
+	name       string
 	log        bool
 	user       *user.User
 }

--- a/daemon.go
+++ b/daemon.go
@@ -123,8 +123,12 @@ func New(cfg *Config) (*Daemon, error) {
 			supDir = filepath.Join(home,
 				fmt.Sprintf("%s", strings.TrimSuffix(serviceFile, filepath.Ext(serviceFile))))
 		} else {
-			supDir = filepath.Join(home,
-				fmt.Sprintf("%d", os.Getpid()))
+			if cfg.name != "" {
+				supDir = filepath.Join(home, cfg.name)
+			} else {
+				supDir = filepath.Join(home,
+					fmt.Sprintf("%d", os.Getpid()))
+			}
 		}
 	}
 

--- a/flags.go
+++ b/flags.go
@@ -11,6 +11,7 @@ type Flags struct {
 	FollowPid   string
 	Logfile     string
 	Logger      string
+	Name        string
 	Nodaemon    bool
 	ParentPid   string
 	Retries     int

--- a/parser.go
+++ b/parser.go
@@ -38,11 +38,12 @@ func (p *Parse) Parse(fs *flag.FlagSet) (*Flags, error) {
 	fs.BoolVar(&p.Flags.CheckConfig, "cc", false, "Checks the config file")
 	fs.StringVar(&p.Flags.ChildPid, "p", "", "Path to write the child `pidfile`")
 	fs.StringVar(&p.Flags.Configfile, "c", "", "`run.yml` configuration file")
-	fs.StringVar(&p.Flags.Ctl, "ctl", "", "Create supervise directory `/var/run/immortal/<service>`")
+	fs.StringVar(&p.Flags.Ctl, "ctl", "", "Create supervise directory `/var/run/immortal/<service>`. Overrides `-name`")
 	fs.StringVar(&p.Flags.Envdir, "e", "", "Set environment variables specified by files in the `dir`")
 	fs.StringVar(&p.Flags.FollowPid, "f", "", "Follow PID in `pidfile`")
 	fs.StringVar(&p.Flags.Logfile, "l", "", "Write stdout/stderr to `logfile`")
 	fs.StringVar(&p.Flags.Logger, "logger", "", "A `command` to pipe stdout/stderr to stdin")
+	fs.StringVar(&p.Flags.Name, "name", "", "A name for the service. This differs from -ctl in that it affects `${HOME}/.immortal/<name>`.")
 	fs.StringVar(&p.Flags.ParentPid, "P", "", "Path to write the supervisor `pidfile`")
 	fs.StringVar(&p.Flags.User, "u", "", "Execute command on behalf `user`")
 	fs.StringVar(&p.Flags.Wrkdir, "d", "", "Change to `dir` before starting the command")
@@ -236,6 +237,9 @@ func ParseArgs(p Parser, fs *flag.FlagSet) (cfg *Config, err error) {
 	cfg.cli = true
 	cfg.command = fs.Args()
 	cfg.ctl = sdir
+	if flags.Name != "" {
+		cfg.name = flags.Name
+	}
 
 	// if -d
 	if flags.Wrkdir != "" {


### PR DESCRIPTION
- [X] Have you test the code?
- [X] Have you check that the existing tests are passing?
- [ ] The destination branch is **develop**?

This is against master, as the "immortal/immortal/develop" branch is 2 years behind.

This change allows user to provide a `-name <name>` argument that will be used instead of the PID in supervisors for services added from the command line by non-root users. For example:

```
$ immortal -name top top -bn 5
$ immortalctl
    PID           Up   Down   Name      CMD
 ... <snip> ...
1676432   1h37m16.1s          1757      skippy-xd --start-daemon
2021609        13.8s          top       top -bd 5
```

After this, the usual `immortalctl` commands of stop, start, and halt using the name work as usual. This makes non-root usage _much_ more convenient, e.g.:

```
$ immortalctl stop top
```

This addresses #74 in that it makes running `immortalctl` commands easier for users, as they do not have to first determine the supervisor PID. This will make scripting easier, as well.

As a design note, I first implemented this through the `-ctl` argument; however, it would have affected the behavior of the root use; `immortal -ctl foo foocommand` would have tried to use `~root/.immortal/` instead of `/var/run/immortal` as was the behavior prior to my change. Since this was a breaking change (whether or not it was much used), I went with adding a new argument.

`-ctl` and `-name` are not compatible; `-ctl` always overrides `-name`. One enhancement would be throwing an error if both are provided; that is not included in this patch.

I do not know why github is listing both changes in the diff, since the other patch has been accepted and merged. I find github's behavior baffling sometimes.