### PR TITLE
Fixes output piping issue

### DIFF
--- a/cmd/immortalctl/main.go
+++ b/cmd/immortalctl/main.go
@@ -269,12 +269,12 @@ func main() {
 				s.Status.Cmd)
 			if s.SignalResponse != nil && s.SignalResponse.Err != "" {
 				if *asciiOnly {
-					println(fmt.Sprintf(" - %s", s.SignalResponse.Err))
+					fmt.Printf(" - %s\n", s.SignalResponse.Err)
 				} else {
-					println(immortal.Yellow(fmt.Sprintf(" - %s", s.SignalResponse.Err)))
+					fmt.Println(immortal.Yellow(fmt.Sprintf(" - %s", s.SignalResponse.Err)))
 				}
 			} else {
-				println()
+				fmt.Println()
 			}
 		} else if s.Status.Status != "" {
 			// print status about process that will start after the defined WAIT value


### PR DESCRIPTION
- [X] Have you test the code?
- [X] Have you check that the existing tests are passing?
- [ ] The destination branch is **develop**?

This is branched off master.

The use of the Go built-in primative `println()` produces undesireable behavior when the output is piped:

```
nivrim » immortalctl
    PID           Up   Down   Name      CMD
1676426   2h19m17.1s          1646      polybar left
1676427   2h19m17.1s          1663      polybar right
1676438   2h19m17.0s          1678      mconnect
1676443   2h19m17.0s          1691      autocutsel -s CLIPBOARD
1676441   2h19m17.0s          1708      autocutsel -s PRIMARY
1676437   2h19m17.0s          1727      mpdris2-rs --host media.lan
1676439   2h19m17.0s          1742      keepassxc
1676432   2h19m17.1s          1757      skippy-xd --start-daemon
1676429   2h19m17.1s          1785      snapclient -h media.lan --hostID nivrim --player pulse --latency 50
1676428   2h19m17.1s          1820      dcnnt fg
1676431   2h19m17.1s          1839      syncthing
2038893     39m46.1s          2038883   xautolock -locker xlock
1676442   2h19m17.0s          3102052   picom
nivrim » immortalctl | grep dcnnt 













1676426   2h19m25.9s          1646      polybar left1676427   2h19m25.9s          1663      polybar right1676438   2h19m25.9s          1678      mconnect1676443   2h19m25.9s          1691      autocutsel -s CLIPBOARD1676441   2h19m25.9s          1708      autocutsel -s PRIMARY1676437   2h19m25.9s          1727      mpdris2-rs --host media.lan1676439   2h19m25.9s          1742      keepassxc1676432   2h19m25.9s          1757      skippy-xd --start-daemon1676429   2h19m25.9s          1785      snapclient -h media.lan --hostID nivrim --player pulse --latency 501676428   2h19m25.9s          1820      dcnnt fg1676431   2h19m25.9s          1839      syncthing2038893     39m55.0s          2038883   xautolock -locker xlock1676442   2h19m25.9s          3102052   picom
```

This patch replaces the 3 places where `println()` is used instead of `fmt.Println()`:

```
nivrim » go run ./cmd/immortalctl | grep dcnnt 
1676428   2h20m59.6s          1820      dcnnt fg
```

This complements the `-A` flag; I didn't catch this issue until after the other PR had been merged.