### PR TITLE
fix: replace deprecated io/ioutil with os (Go 1.16+)

### DIFF
--- a/ctl.go
+++ b/ctl.go
@@ -2,7 +2,6 @@ package immortal
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -49,7 +48,7 @@ func (c *Controller) SendSignal(socket, signal string) (*SignalResponse, error) 
 
 // FindServices return [name, socket path] of service
 func (c *Controller) FindServices(dir string) ([]*ServiceStatus, error) {
-	sdir, err := ioutil.ReadDir(dir)
+	sdir, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +76,7 @@ func (c *Controller) FindServices(dir string) ([]*ServiceStatus, error) {
 // PurgeServices remove unused service directory
 func (c *Controller) PurgeServices(dir string) error {
 	sdir := []string{"lock", "immortal.sock"}
-	files, err := ioutil.ReadDir(filepath.Dir(dir))
+	files, err := os.ReadDir(filepath.Dir(dir))
 	if err != nil {
 		return err
 	}

--- a/daemon.go
+++ b/daemon.go
@@ -3,9 +3,8 @@ package immortal
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
-	"log"
 	"os"
+	"log"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -76,7 +75,7 @@ func (d *Daemon) Run(p Process) (*process, error) {
 
 // WritePid write pid to file
 func (d *Daemon) WritePid(file string, pid int) error {
-	return ioutil.WriteFile(file, []byte(fmt.Sprintf("%d", pid)), 0644)
+	return os.WriteFile(file, []byte(fmt.Sprintf("%d", pid)), 0644)
 }
 
 // IsRunning check if process is running
@@ -90,7 +89,7 @@ func (d *Daemon) IsRunning(pid int) bool {
 
 // ReadPidFile read pid from file if error returns pid 0
 func (d *Daemon) ReadPidFile(pidfile string) (int, error) {
-	content, err := ioutil.ReadFile(pidfile)
+	content, err := os.ReadFile(pidfile)
 	if err != nil {
 		return 0, err
 	}

--- a/parser.go
+++ b/parser.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -57,7 +56,7 @@ func (p *Parse) Parse(fs *flag.FlagSet) (*Flags, error) {
 }
 
 func (p *Parse) parseYml(file string) (*Config, error) {
-	f, err := ioutil.ReadFile(file)
+	f, err := os.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}
@@ -80,13 +79,13 @@ func (p *Parse) parseEnvdir(dir string) (map[string]string, error) {
 	if !isDir(dir) {
 		return nil, fmt.Errorf("-e %q does not exist or has wrong permissions, use (\"%s -h\") for help", dir, os.Args[0])
 	}
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, err
 	}
 	env := make(map[string]string)
 	for _, f := range files {
-		if f.Mode().IsRegular() {
+		if f.Type().IsRegular() {
 			lines := 0
 			ff, err := os.Open(filepath.Join(dir, f.Name()))
 			if err != nil {


### PR DESCRIPTION
## Summary
Replace deprecated `io/ioutil` package usages with `os` package equivalents (Go 1.16+ deprecation).

## Changes
- `ctl.go`: `ioutil.ReadDir` → `os.ReadDir` (2 locations)
- `daemon.go`: `ioutil.WriteFile` → `os.WriteFile`, `ioutil.ReadFile` → `os.ReadFile`
- `parser.go`: `ioutil.ReadFile` → `os.ReadFile`, `ioutil.ReadDir` → `os.ReadDir`

## API Note
`os.ReadDir` returns `[]os.DirEntry` (not `[]os.FileInfo`). The code changes adjust for this:
- `parser.go`: uses `f.Type().IsRegular()` instead of `f.Mode().IsRegular()`
- All other usages (`file.Name()`, `file.IsDir()`) are compatible with `os.DirEntry`

## Testing
The repository uses Go 1.22 (`go.mod` specifies `go 1.22`), confirming `io/ioutil` is deprecated.

---
fixes deprecated io/ioutil usage per Go 1.16+ migration guide